### PR TITLE
8 add xml utilities module

### DIFF
--- a/src/dander/__about__.py
+++ b/src/dander/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Daniel Lawson <daniel.lawson@rmit.edu.au>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/dander/cli.py
+++ b/src/dander/cli.py
@@ -4,10 +4,13 @@ from typing import Annotated
 import typer
 from loguru import logger
 import dander.io.json_utils as json_utils
+import dander.io.xml_utils as xml_utils
 
 app = typer.Typer()
 json_app = typer.Typer()
 app.add_typer(json_app, name="json")
+xml_app = typer.Typer()
+app.add_typer(xml_app, name="xml")
 
 
 @json_app.command("format")
@@ -53,6 +56,45 @@ def split_json_file(
     except ValueError as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(code=1)
+
+
+@xml_app.command("format")
+def reformat_xml(
+    file_path: str,
+    *,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            "-s",
+            help="Enforce strict-mode XML formatting, input file must be an XML file.",
+        ),
+    ] = True,
+    indent: Annotated[
+        int,
+        typer.Option(
+            "--indent",
+            "-i",
+            help="Number of spaces used per indentation level for XML formatting.",
+        ),
+    ] = 2,
+    write_file: Annotated[
+        bool,
+        typer.Option("--write", "-w", help="Write formatted XML to file in-place."),
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Print formatted XML to console.")
+    ] = False,
+):
+    logger.add(
+        sys.stderr,
+        format="{time} {level} {message}",
+        filter="my_module",
+        level="DEBUG" if verbose else "INFO",
+    )
+    xml_utils.reformat_xml_file(
+        file_path, strict=strict, indent=indent, write_file=write_file, verbose=verbose
+    )
 
 
 @app.command()

--- a/src/dander/io/xml_utils.py
+++ b/src/dander/io/xml_utils.py
@@ -48,6 +48,6 @@ def reformat_xml_file(
         xml_file_path.write_text(xml_data)
 
 
-if __name__ == "__main__":
-    file = r"C:\Users\E124584\Downloads\denodo__v_enrol_all__diagram.svg"
+    # Example usage: replace 'example.xml' with your XML file path
+    file = "example.xml"
     reformat_xml_file(file, strict=False, write_file=True)

--- a/src/dander/io/xml_utils.py
+++ b/src/dander/io/xml_utils.py
@@ -29,11 +29,6 @@ def reformat_xml_file(
     import rich
 
     xml_file_path = Path(file_path)
-    if not xml_file_path.is_file():
-        raise FileNotFoundError(f"File not found: {xml_file_path}")
-    if strict and not xml_file_path.suffix == ".xml":
-        raise ValueError(f"File is not an XML file: {xml_file_path}")
-
     xml_file_content = get_xml_file_contents(file_path, strict=strict)
     xml_data = pretty_print_xml(xml_file_content, indent=indent)
     logger.debug(

--- a/src/dander/io/xml_utils.py
+++ b/src/dander/io/xml_utils.py
@@ -1,0 +1,53 @@
+from xml.dom import minidom
+from pathlib import Path
+from loguru import logger
+
+
+def pretty_print_xml(xml: str, indent: int = 2):
+    reparsed = minidom.parseString(xml)
+    return reparsed.toprettyxml(indent=" " * indent)
+
+
+def get_xml_file_contents(file_path: str, strict: bool = True):
+    file_path = Path(file_path)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"File not found: {file_path}")
+    if strict and not file_path.suffix == ".xml":
+        raise ValueError(f"File is not an XML file: {file_path}")
+    with file_path.open() as f:
+        return f.read()
+
+
+def reformat_xml_file(
+    file_path: str,
+    strict: bool = True,
+    indent: int = 2,
+    write_file: bool = False,
+    verbose: bool = False,
+):
+    """Reformat an XML file. Optionally write in-place or print to console."""
+    import rich
+
+    xml_file_path = Path(file_path)
+    if not xml_file_path.is_file():
+        raise FileNotFoundError(f"File not found: {xml_file_path}")
+    if strict and not xml_file_path.suffix == ".xml":
+        raise ValueError(f"File is not an XML file: {xml_file_path}")
+
+    xml_file_content = get_xml_file_contents(file_path, strict=strict)
+    xml_data = pretty_print_xml(xml_file_content, indent=indent)
+    logger.debug(
+        f"Reformatted XML file: {xml_file_path.name} (strict={strict}, indent={indent})"
+    )
+
+    if not write_file or verbose:
+        logger.debug("Printing formatted XML to console")
+        rich.print(xml_data)
+    else:
+        logger.debug("Writing formatted XML to file in-place")
+        xml_file_path.write_text(xml_data)
+
+
+if __name__ == "__main__":
+    file = r"C:\Users\E124584\Downloads\denodo__v_enrol_all__diagram.svg"
+    reformat_xml_file(file, strict=False, write_file=True)

--- a/src/dander/io/xml_utils.py
+++ b/src/dander/io/xml_utils.py
@@ -26,8 +26,6 @@ def reformat_xml_file(
     verbose: bool = False,
 ):
     """Reformat an XML file. Optionally write in-place or print to console."""
-    import rich
-
     xml_file_path = Path(file_path)
     xml_file_content = get_xml_file_contents(file_path, strict=strict)
     xml_data = pretty_print_xml(xml_file_content, indent=indent)

--- a/src/dander/io/xml_utils.py
+++ b/src/dander/io/xml_utils.py
@@ -39,8 +39,3 @@ def reformat_xml_file(
     else:
         logger.debug("Writing formatted XML to file in-place")
         xml_file_path.write_text(xml_data)
-
-
-    # Example usage: replace 'example.xml' with your XML file path
-    file = "example.xml"
-    reformat_xml_file(file, strict=False, write_file=True)


### PR DESCRIPTION
This pull request introduces XML file formatting support to the CLI, similar to the existing JSON utilities. The main changes include adding an `xml` command group to the CLI, implementing a new `reformat_xml` command, and providing the underlying XML formatting utilities.

**CLI Enhancements:**

* Added a new `xml` command group to the CLI, allowing users to run XML-specific commands such as formatting (`src/dander/cli.py`).
* Implemented the `reformat_xml` command under the `xml` group, enabling users to reformat XML files with options for strict mode, indentation, in-place writing, and verbosity (`src/dander/cli.py`).

**XML Utilities:**

* Added the new `xml_utils.py` module, which provides functions for pretty-printing XML, validating XML file input, and performing the actual reformatting logic, including optional in-place writing and console output (`src/dander/io/xml_utils.py`).